### PR TITLE
개별 통계 API 정리 및 통합 API 사용 최적화

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Users, CalendarDays, AlertCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
-import { fetchFromAPI } from "@/lib/api-service"
+import { getDashboardStats } from "@/lib/api-service"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 
@@ -97,19 +97,16 @@ export default function Home() {
       try {
         setLoading(true)
 
-        // 병렬로 API 호출
-        const [userStatsData, desertStatsData] = await Promise.all([
-          fetchFromAPI("/user/stats"),
-          fetchFromAPI("/desert/stats"),
-        ])
+        // 통합 대시보드 API 호출 - 한 번의 요청으로 모든 데이터 조회
+        const dashboardStatsData = await getDashboardStats()
 
-        setUserStats(userStatsData)
-        setDesertStats(desertStatsData)
+        setUserStats(dashboardStatsData.userStats)
+        setDesertStats(dashboardStatsData.desertStats)
         setError(null)
 
         console.log('데이터 로드 완료:', {
-          totalUsers: userStatsData?.totalUsers,
-          totalDesert: desertStatsData?.totalDesert 
+          totalUsers: dashboardStatsData.userStats?.totalUsers,
+          totalDesert: dashboardStatsData.desertStats?.totalDesert 
         })
       } catch (err) {
         console.error("데이터를 불러오는데 실패했습니다:", err)

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -216,11 +216,21 @@ export async function refreshDashboardStats() {
   })
 }
 
-// 기존 개별 통계 API (하위 호환성 유지)
+// 기존 개별 통계 API (하위 호환성 유지) - DEPRECATED
+/**
+ * @deprecated 이 함수는 더 이상 사용되지 않습니다. getDashboardStats()를 사용하세요.
+ * @see getDashboardStats
+ */
 export async function getUserStats() {
+  console.warn('[DEPRECATED] getUserStats()는 deprecated되었습니다. getDashboardStats()를 사용하세요.')
   return fetchFromAPI('/user/stats')
 }
 
+/**
+ * @deprecated 이 함수는 더 이상 사용되지 않습니다. getDashboardStats()를 사용하세요.
+ * @see getDashboardStats
+ */
 export async function getDesertStats() {
+  console.warn('[DEPRECATED] getDesertStats()는 deprecated되었습니다. getDashboardStats()를 사용하세요.')
   return fetchFromAPI('/desert/stats')
 }


### PR DESCRIPTION
## 📋 Summary
개별 통계 API 엔드포인트들을 deprecated 처리하고 통합 API만 사용하도록 정리했습니다.

### 🎯 변경 사항
- **백엔드**: `/user/stats`, `/desert/stats` 엔드포인트 deprecated 처리
- **프론트엔드**: `getUserStats()`, `getDesertStats()` 함수 deprecated 처리
- **성능 최적화**: 2개 API 호출 → 1개 통합 API 호출로 개선

### 🔄 API 호출 최적화
**Before**: 
```typescript
const [userStats, desertStats] = await Promise.all([
  fetchFromAPI('/user/stats'),
  fetchFromAPI('/desert/stats') 
])
```

**After**:
```typescript
const dashboardData = await getDashboardStats() // 통합 API 1회 호출
```

### ⚠️ Deprecated 경고
- 백엔드: 로그에 `[DEPRECATED]` 경고 메시지 출력
- 프론트엔드: 콘솔에 `console.warn()` 경고 메시지 출력
- Swagger 문서에 deprecated 표시 및 대안 API 안내

### 📈 성능 개선 효과
- 네트워크 요청 수 **50% 감소** (2개 → 1개)
- 응답 시간 단축 및 서버 부하 감소
- UI 로딩 성능 향상

### 📝 하위 호환성
- 기존 API는 여전히 동작하지만 deprecated 경고 출력
- 점진적 마이그레이션 지원
- 1-2주 모니터링 후 완전 제거 고려

## Test plan
- [x] `/user/stats` 호출 시 deprecated 경고 로그 확인
- [x] `/desert/stats` 호출 시 deprecated 경고 로그 확인  
- [x] `/dashboard/stats` 통합 API 정상 동작 확인
- [x] 프론트엔드에서 통합 API만 사용하는지 확인
- [x] 개별 API 함수 호출 시 콘솔 경고 메시지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)