### PR TITLE
feat: 닉네임 수정 기능 구현 및 JWT 토큰 동기화 개선

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -111,7 +111,7 @@ const authOptions: AuthOptions = {
     error: '/login'
   },
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
       if (user) {
         token.accessToken = user.accessToken
         token.serverAllianceId = user.serverAllianceId
@@ -122,6 +122,24 @@ const authOptions: AuthOptions = {
         token.userId = user.id
         token.kakaoId = user.kakaoId
       }
+      
+      // 세션 업데이트 시 토큰 갱신
+      if (trigger === "update" && session) {
+        if (session.user?.nickname) {
+          token.name = session.user.nickname
+        }
+        if (session.user?.name) {
+          token.name = session.user.name
+        }
+        // 다른 사용자 정보 필드들도 업데이트 가능
+        if (session.user?.serverAllianceId) {
+          token.serverAllianceId = session.user.serverAllianceId
+        }
+        if (session.user?.role) {
+          token.role = session.user.role
+        }
+      }
+      
       return token
     },
     async session({ session, token }) {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -24,6 +24,18 @@ export default function LoginPage() {
     }
   }, [status, session, router])
 
+  // 닉네임 업데이트 메시지 표시
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search)
+    if (urlParams.get('message') === 'nickname-updated') {
+      toast({
+        title: "닉네임 변경 완료",
+        description: "닉네임이 성공적으로 변경되었습니다. 다시 로그인해주세요.",
+        variant: "default"
+      })
+    }
+  }, [])
+
   const handleKakaoLogin = async () => {
     if (isLoading) return
 

--- a/components/user/nickname-edit-modal.tsx
+++ b/components/user/nickname-edit-modal.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useState } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useToast } from "@/hooks/use-toast"
+import { Loader2, Edit2 } from "lucide-react"
+import { updateNickname } from "@/lib/api-service"
+
+interface NicknameEditModalProps {
+  isOpen: boolean
+  onClose: () => void
+  currentNickname: string
+  onSuccess: (newNickname: string) => void
+}
+
+export function NicknameEditModal({ 
+  isOpen, 
+  onClose, 
+  currentNickname, 
+  onSuccess 
+}: NicknameEditModalProps) {
+  const { toast } = useToast()
+  const [nickname, setNickname] = useState(currentNickname)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    
+    if (!nickname.trim()) {
+      toast({
+        title: "오류",
+        description: "닉네임을 입력해주세요.",
+        variant: "destructive"
+      })
+      return
+    }
+
+    if (nickname.trim() === currentNickname) {
+      toast({
+        title: "알림",
+        description: "기존 닉네임과 동일합니다.",
+        variant: "default"
+      })
+      return
+    }
+
+    if (nickname.trim().length < 2 || nickname.trim().length > 20) {
+      toast({
+        title: "오류",
+        description: "닉네임은 2-20자 사이여야 합니다.",
+        variant: "destructive"
+      })
+      return
+    }
+
+    setIsLoading(true)
+    
+    try {
+      const data = await updateNickname(nickname.trim())
+
+      if (data.success) {
+        toast({
+          title: "성공",
+          description: "닉네임이 변경되었습니다. 새로운 토큰으로 다시 로그인됩니다.",
+          variant: "default"
+        })
+        
+        onSuccess(nickname.trim())
+        onClose()
+      } else {
+        throw new Error(data.message || '닉네임 수정에 실패했습니다.')
+      }
+    } catch (error) {
+      console.error('닉네임 수정 오류:', error)
+      toast({
+        title: "오류",
+        description: error instanceof Error ? error.message : '닉네임 수정 중 오류가 발생했습니다.',
+        variant: "destructive"
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (!isLoading) {
+      setNickname(currentNickname) // 원래 닉네임으로 되돌리기
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Edit2 className="h-5 w-5" />
+            닉네임 수정
+          </DialogTitle>
+        </DialogHeader>
+        
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="nickname">새로운 닉네임</Label>
+            <Input
+              id="nickname"
+              type="text"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              placeholder="새로운 닉네임을 입력하세요"
+              disabled={isLoading}
+              maxLength={20}
+              className="w-full"
+            />
+            <p className="text-xs text-muted-foreground">
+              2-20자 사이로 입력해주세요. 현재: {nickname.length}자
+            </p>
+          </div>
+
+          <div className="flex gap-2 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={isLoading}
+              className="flex-1"
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              disabled={isLoading || nickname.trim() === currentNickname}
+              className="flex-1"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  수정 중...
+                </>
+              ) : (
+                "수정하기"
+              )}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -243,3 +243,14 @@ export async function getDesertStats() {
   console.warn('[DEPRECATED] getDesertStats()는 deprecated되었습니다. getDashboardStats()를 사용하세요.')
   return fetchFromAPI('/desert/stats')
 }
+
+// 닉네임 수정 API
+export async function updateNickname(nickname: string) {
+  return fetchFromAPI('/user/profile/nickname', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ nickname })
+  })
+}


### PR DESCRIPTION
## Summary
사이드바에서 접근 가능한 닉네임 수정 기능을 구현하고, JWT 토큰 동기화 문제를 해결했습니다.

### ✨ 주요 기능

#### 1. 닉네임 수정 모달 컴포넌트
- 사이드바 사용자 정보 영역에서 클릭으로 접근
- 실시간 입력 검증 (2-20자 제한)
- 기존 닉네임과 동일한 경우 방지
- 로딩 상태 및 에러 처리

#### 2. JWT 토큰 동기화 개선
- 닉네임 변경 후 자동 로그아웃 방식 적용
- NextAuth 세션 업데이트 로직 개선
- JWT 콜백에서 name 필드 동기화

#### 3. 사용자 경험 개선
- 명확한 성공/실패 메시지 제공
- 로그인 페이지에서 닉네임 변경 완료 알림
- 반응형 디자인 지원 (데스크톱/모바일)

### 🔧 구현 세부사항

#### 컴포넌트 구조
```
components/
├── sidebar.tsx              # 닉네임 수정 모달 통합
└── user/
    └── nickname-edit-modal.tsx   # 닉네임 수정 모달
```

#### API 통합
- `lib/api-service.ts`에 `updateNickname()` 함수 추가
- Account 기반 백엔드 API와 연동
- 적절한 에러 처리 및 타입 안전성

#### NextAuth 설정 개선
- JWT 콜백에서 세션 업데이트 지원
- name과 nickname 필드 동기화
- 세션 트리거 "update" 처리

### 📱 사용자 플로우
1. 사이드바에서 사용자 정보 영역 클릭
2. 닉네임 수정 모달 열기
3. 새로운 닉네임 입력 및 검증
4. 수정 요청 전송
5. 성공 시 자동 로그아웃
6. 로그인 페이지에서 완료 메시지 확인
7. 재로그인으로 새 닉네임 반영

### 🎨 UI/UX 특징
- ShadCN UI 컴포넌트 사용으로 일관된 디자인
- Edit2 아이콘으로 수정 가능성 직관적 표시
- 호버 효과로 인터랙션 가능성 강조
- 로딩 스피너와 함께 명확한 피드백

🤖 Generated with [Claude Code](https://claude.ai/code)