### PR TITLE
유저 목록 프론트엔드 기본 정렬 동기화

### DIFF
--- a/components/user/user-list.tsx
+++ b/components/user/user-list.tsx
@@ -48,6 +48,7 @@ export function UserList({ users, onEdit, onDeleted }: UserListProps) {
     return `${power.toFixed(1)}M`
   }
 
+  // 백엔드 기본 정렬과 일치: 연맹활동중 -> 등급 -> 전투력 순
   const [sortField, setSortField] = useState<keyof User | null>(null)
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc")
 
@@ -61,8 +62,25 @@ export function UserList({ users, onEdit, onDeleted }: UserListProps) {
   }
 
   const sortedUsers = [...users].sort((a, b) => {
-    if (!sortField) return 0
+    // 프론트엔드에서 정렬이 선택되지 않은 경우, 백엔드 기본 정렬 유지
+    if (!sortField) {
+      // 백엔드와 동일한 정렬: leave(asc) -> userGrade(desc) -> power(desc)
+      
+      // 1. 연맹활동중 우선 (leave = false가 먼저)
+      if (a.leave !== b.leave) {
+        return a.leave ? 1 : -1
+      }
+      
+      // 2. 등급 내림차순 (R5, R4, R3... 순)
+      if (a.userGrade !== b.userGrade) {
+        return b.userGrade.localeCompare(a.userGrade)
+      }
+      
+      // 3. 전투력 내림차순 (높은순)
+      return b.power - a.power
+    }
 
+    // 사용자가 특정 필드로 정렬을 선택한 경우
     const aValue = a[sortField]
     const bValue = b[sortField]
 


### PR DESCRIPTION
## Summary
백엔드에서 변경된 유저 목록 기본 정렬 순서에 맞춰 프론트엔드의 기본 정렬 로직을 동기화했습니다.

## 주요 변경사항

### 🔄 프론트엔드 기본 정렬 동기화
- `UserList` 컴포넌트의 `sortedUsers` 로직 개선
- 백엔드와 동일한 기본 정렬 순서 적용:
  1. **연맹활동중** (`leave = false` 우선)
  2. **등급** (`userGrade` 내림차순: R5 → R4 → R3...)
  3. **전투력** (`power` 내림차순: 높은순)

### 📱 사용자 경험 개선
- 정렬 필드를 선택하지 않은 기본 상태에서 백엔드와 동일한 정렬 적용
- 사용자가 테이블 헤더를 클릭하면 해당 필드로 개별 정렬 가능
- 백엔드-프론트엔드 간 정렬 일관성 보장

### 🔧 코드 개선사항
```typescript
// 백엔드와 동일한 정렬: leave(asc) -> userGrade(desc) -> power(desc)

// 1. 연맹활동중 우선 (leave = false가 먼저)
if (a.leave !== b.leave) {
  return a.leave ? 1 : -1
}

// 2. 등급 내림차순 (R5, R4, R3... 순)
if (a.userGrade !== b.userGrade) {
  return b.userGrade.localeCompare(a.userGrade)
}

// 3. 전투력 내림차순 (높은순)
return b.power - a.power
```

## 기대 효과
- 백엔드-프론트엔드 간 일관된 정렬 순서 제공
- 사용자가 새로고침하거나 페이지를 다시 로드해도 동일한 순서 유지
- 개별 필드 정렬 기능은 기존과 동일하게 작동

## Test Plan
- [ ] 페이지 로드 시 연맹활동중 → 등급 → 전투력 순으로 정렬되는지 확인
- [ ] 테이블 헤더 클릭 시 개별 필드 정렬이 정상 작동하는지 확인
- [ ] 정렬을 해제했을 때 기본 정렬로 돌아가는지 확인
- [ ] 반응형 디자인에서도 정렬이 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)