### PR TITLE
feat: 스쿼드 관리 페이지 연맹등급 정렬 기능 추가

### DIFF
--- a/app/actions/squad-actions.ts
+++ b/app/actions/squad-actions.ts
@@ -12,6 +12,7 @@ export interface SquadMember {
   userName: string
   userLevel: number
   userPower: number
+  userGrade: string
   intentType: string
   isCandidate: boolean
   isPlayed: boolean


### PR DESCRIPTION
## 📝 Summary

스쿼드 관리 페이지에 연맹등급 정렬 기능을 추가하여 사용자 편의성을 개선했습니다.

### 🎯 주요 변경사항

#### 1. 연맹등급 정렬 시스템 구현
- **연맹등급 우선순위**: R5 → R4 → R3 → R2 → R1 → 미지정 순
- **2차 정렬**: 동일 등급 내에서 전투력 순 정렬
- **정렬 방향**: 오름차순/내림차순 토글 가능

#### 2. 사용자 정보 표시 개선
- **기존**: 닉네임/레벨/전투력
- **변경**: 닉네임/레벨/전투력/연맹등급
- 모든 화면에서 일관된 표시 (카드뷰, 다이얼로그, 클립보드 복사)

#### 3. UI/UX 개선
- 정렬 버튼 개선: "전투력" ↔ "연맹등급" 토글
- 방향 버튼: ↑(오름차순) / ↓(내림차순)
- 현재 정렬 상태를 시각적으로 표시

#### 4. 섹션별 정렬 적용
- A조, A조 예비, B조, B조 예비 각 섹션에 개별 적용
- AB 가능, 미배정 섹션은 기존 방식 유지

### 🔧 기술적 변경사항

#### TypeScript 타입 업데이트
```typescript
export interface SquadMember {
  // ... 기존 필드들
  userGrade: string  // 새로 추가
}
```

#### 정렬 로직 개선
```typescript
const sortUsers = (
  users: SquadMember[], 
  powerDirection: "asc" | "desc" = "desc",
  sortByGrade: boolean = false  // 새로 추가
): SquadMember[]
```

#### 상태 관리 추가
```typescript
const [sortByGrade, setSortByGrade] = useState<boolean>(false)
```

### 📋 Test Plan

- [ ] 연맹등급 정렬 토글 동작 확인
- [ ] R5→R4→R3→R2→R1→미지정 순 정렬 확인
- [ ] 동일 등급 내 전투력 정렬 확인
- [ ] 오름차순/내림차순 방향 변경 확인
- [ ] A조, A조 예비, B조, B조 예비 각 섹션별 정렬 확인
- [ ] 사용자 이동 시 정렬 유지 확인
- [ ] 클립보드 복사 시 연맹등급 포함 확인
- [ ] 반응형 디자인 (모바일/태블릿) 확인

### 🎨 스크린샷

#### 정렬 버튼 UI 개선
![정렬 버튼](image-url-here)

#### 사용자 정보 표시 개선
![사용자 카드](image-url-here)

### 📝 사용법

1. **연맹등급 정렬 활성화**: "연맹등급" 버튼 클릭
2. **전투력 정렬로 변경**: "전투력" 버튼 클릭  
3. **정렬 방향 변경**: ↑/↓ 버튼 클릭
4. **결과 확인**: 각 섹션에서 R5 → R4 → R3 순으로 정렬됨

### ⚠️ 주의사항

- 백엔드 API에서 `userGrade` 필드를 제공해야 합니다
- 기존 전투력 정렬 기능은 그대로 유지됩니다
- AB 가능, 미배정 섹션은 기존 정렬 방식을 유지합니다

🤖 Generated with [Claude Code](https://claude.ai/code)