### PR TITLE
feat: 사막전 생성/수정 시 사용자 친화적 에러 메시지 개선

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -318,13 +318,18 @@ export default function EventsPage() {
       // 에러 메시지 추출
       const errorMessage = error instanceof Error ? error.message : "사막전 생성 중 오류가 발생했습니다."
 
-      // 400 에러 관련 메시지인지 확인
+      // 중복 사막전 에러 메시지인지 확인 (백엔드 메시지 패턴 매칭)
       const isDuplicateError =
-        errorMessage.includes("이미 존재") || errorMessage.includes("중복") || errorMessage.includes("동일한")
+        errorMessage.includes("이미 존재") || 
+        errorMessage.includes("중복") || 
+        errorMessage.includes("동일한") ||
+        errorMessage.includes("해당 날짜")
 
       toast({
         title: "사막전 생성 실패",
-        description: isDuplicateError ? "이미 동일한 제목 또는 날짜의 사막전이 존재합니다." : errorMessage,
+        description: isDuplicateError 
+          ? `선택한 날짜(${format(newEventDate, "yyyy년 MM월 dd일")})에 이미 사막전이 존재합니다. 다른 날짜를 선택해주세요.`
+          : errorMessage,
         variant: "destructive"
       })
     } finally {

--- a/components/desert/desert-edit-dialog.tsx
+++ b/components/desert/desert-edit-dialog.tsx
@@ -62,9 +62,37 @@ export function DesertEditDialog({ isOpen, desert, onClose, onUpdate }: DesertEd
       onClose()
     } catch (error) {
       console.error("사막전 수정 실패:", error)
+      
+      // 에러 메시지 추출
+      const errorMessage = error instanceof Error ? error.message : "사막전 수정 중 오류가 발생했습니다."
+      
+      // 중복 날짜 에러 메시지인지 확인
+      const isDuplicateError =
+        errorMessage.includes("이미 존재") || 
+        errorMessage.includes("중복") || 
+        errorMessage.includes("해당 날짜")
+      
+      // 권한 관련 에러 메시지인지 확인
+      const isPermissionError = 
+        errorMessage.includes("다른 연맹") || 
+        errorMessage.includes("권한") ||
+        errorMessage.includes("수정할 수 없습니다")
+      
+      let description = errorMessage
+      if (isDuplicateError) {
+        const selectedDate = new Date(eventDate).toLocaleDateString('ko-KR', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric'
+        })
+        description = `선택한 날짜(${selectedDate})에 이미 사막전이 존재합니다. 다른 날짜를 선택해주세요.`
+      } else if (isPermissionError) {
+        description = "이 사막전을 수정할 권한이 없습니다."
+      }
+      
       toast({
-        title: "오류",
-        description: "사막전 수정 중 오류가 발생했습니다.",
+        title: "사막전 수정 실패",
+        description,
         variant: "destructive",
       })
     } finally {


### PR DESCRIPTION
## Summary
- ✅ 사막전 중복 생성 에러 메시지 사용자 친화적 개선
- ✅ 백엔드 멀티테넌트 제약조건과 연동된 정확한 에러 안내
- ✅ 권한 에러와 중복 에러 구분 처리
- ✅ 사용자 액션 가이드 메시지 추가

## Changes Made

### 📱 사막전 생성 페이지 (events/page.tsx)

#### **에러 감지 패턴 확장**
```typescript
// 백엔드 메시지 패턴 매칭 강화
const isDuplicateError =
  errorMessage.includes("이미 존재") || 
  errorMessage.includes("중복") || 
  errorMessage.includes("동일한") ||
  errorMessage.includes("해당 날짜")  // ✅ 새로 추가
```

#### **구체적인 에러 메시지**
```typescript
// 기존
description: "이미 동일한 제목 또는 날짜의 사막전이 존재합니다."

// 개선
description: `선택한 날짜(${format(newEventDate, "yyyy년 MM월 dd일")})에 이미 사막전이 존재합니다. 다른 날짜를 선택해주세요.`
```

### 🛠️ 사막전 수정 다이얼로그 (desert-edit-dialog.tsx)

#### **에러 타입별 구분 처리**
```typescript
// 중복 날짜 에러 확인
const isDuplicateError = 
  errorMessage.includes("이미 존재") || 
  errorMessage.includes("중복") || 
  errorMessage.includes("해당 날짜")

// 권한 관련 에러 확인
const isPermissionError = 
  errorMessage.includes("다른 연맹") || 
  errorMessage.includes("권한") ||
  errorMessage.includes("수정할 수 없습니다")
```

#### **에러별 맞춤 메시지**
```typescript
if (isDuplicateError) {
  // 선택한 날짜 포함한 안내
  description = `선택한 날짜(${selectedDate})에 이미 사막전이 존재합니다. 다른 날짜를 선택해주세요.`
} else if (isPermissionError) {
  // 권한 에러 명확한 안내
  description = "이 사막전을 수정할 권한이 없습니다."
}
```

## User Experience Improvements

### 🎯 개선된 사용자 경험

#### **Before (기존)**
- ❌ "사막전이 이미 존재합니다. 2025-07-25"
- ❌ "사막전 수정 중 오류가 발생했습니다."
- ❌ 구체적인 해결 방법 안내 부족

#### **After (개선)**
- ✅ "선택한 날짜(2025년 07월 25일)에 이미 사막전이 존재합니다. 다른 날짜를 선택해주세요."
- ✅ "이 사막전을 수정할 권한이 없습니다."
- ✅ 사용자가 취해야 할 다음 액션 명시

## Integration with Backend

### 🔗 백엔드 연동 확인
- **멀티테넌트 제약조건**: `UNIQUE (event_date, server_alliance_id)`
- **400 에러 응답**: `IllegalArgumentException` → `GlobalExceptionHandler`
- **에러 메시지 형식**: `{"error": "해당 날짜(2025-07-25)에 이미 사막전이 존재합니다."}`

## Test Scenarios

### 🧪 테스트 시나리오
- [x] 같은 alliance 내 중복 날짜 사막전 생성 → 명확한 에러 안내
- [x] 다른 alliance 사막전 수정 시도 → 권한 에러 안내  
- [x] 날짜 포맷팅이 올바르게 표시되는지 확인
- [x] "다른 날짜를 선택해주세요" 액션 가이드 메시지 확인
- [x] 일반적인 네트워크 에러 시 fallback 메시지 표시

🤖 Generated with [Claude Code](https://claude.ai/code)