### PR TITLE
feat: 토스트 메시지 위치 변경 및 공략 공유 페이지 추가

### DIFF
--- a/app/strategy/loading.tsx
+++ b/app/strategy/loading.tsx
@@ -1,0 +1,63 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+export default function StrategyLoading() {
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* 헤더 스켈레톤 */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-8 rounded" />
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-32" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+        </div>
+      </div>
+
+      {/* 메인 카드 스켈레톤 */}
+      <Card className="border-dashed border-2">
+        <CardHeader className="text-center pb-4">
+          <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center">
+            <Skeleton className="h-20 w-20 rounded-full" />
+          </div>
+          <Skeleton className="h-8 w-48 mx-auto mb-2" />
+          <Skeleton className="h-4 w-96 mx-auto mb-1" />
+          <Skeleton className="h-4 w-80 mx-auto" />
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="grid gap-4 md:grid-cols-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex flex-col items-center text-center p-4 rounded-lg bg-muted/30">
+                <Skeleton className="h-8 w-8 rounded mb-2" />
+                <Skeleton className="h-5 w-24 mb-1" />
+                <Skeleton className="h-4 w-full mb-1" />
+                <Skeleton className="h-4 w-3/4" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 추가 정보 카드 스켈레톤 */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="flex items-start gap-3">
+                <Skeleton className="w-2 h-2 rounded-full mt-2 flex-shrink-0" />
+                <div className="space-y-1 flex-1">
+                  <Skeleton className="h-5 w-32" />
+                  <Skeleton className="h-4 w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/strategy/page.tsx
+++ b/app/strategy/page.tsx
@@ -27,7 +27,7 @@ export default function StrategyPage() {
           </div>
           <CardTitle className="text-2xl">오픈 준비중입니다</CardTitle>
           <CardDescription className="text-base max-w-md mx-auto">
-            연맹원들이 서로의 공략과 전략을 공유할 수 있는 게시판을 준비하고 있습니다.
+            다양한 서버 연맹에서 공략과 전략을 공유할 수 있는 게시판을 준비하고 있습니다.
             곧 만나볼 수 있도록 열심히 개발 중이니 조금만 기다려주세요!
           </CardDescription>
         </CardHeader>
@@ -35,9 +35,9 @@ export default function StrategyPage() {
           <div className="grid gap-4 md:grid-cols-3">
             <div className="flex flex-col items-center text-center p-4 rounded-lg bg-muted/30">
               <Users className="h-8 w-8 text-primary mb-2" />
-              <h3 className="font-semibold mb-1">연맹원 소통</h3>
+              <h3 className="font-semibold mb-1">서버 간 공유</h3>
               <p className="text-sm text-muted-foreground">
-                연맹원들과 함께 전략을 공유하고 토론할 수 있습니다
+                다양한 서버 연맹들과 전략을 공유하고 토론할 수 있습니다
               </p>
             </div>
             <div className="flex flex-col items-center text-center p-4 rounded-lg bg-muted/30">
@@ -68,8 +68,8 @@ export default function StrategyPage() {
             <div className="flex items-start gap-3">
               <div className="w-2 h-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
               <div>
-                <h4 className="font-medium">전략 게시판</h4>
-                <p className="text-sm text-muted-foreground">사막전, 연맹전 등 다양한 콘텐츠별 전략 공유</p>
+                <h4 className="font-medium">서버전 전략 게시판</h4>
+                <p className="text-sm text-muted-foreground">사막전, 서버전 등 다양한 콘텐츠별 전략 공유</p>
               </div>
             </div>
             <div className="flex items-start gap-3">
@@ -83,7 +83,7 @@ export default function StrategyPage() {
               <div className="w-2 h-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
               <div>
                 <h4 className="font-medium">질문 & 답변</h4>
-                <p className="text-sm text-muted-foreground">궁금한 점을 물어보고 연맹원들이 답변해주는 공간</p>
+                <p className="text-sm text-muted-foreground">궁금한 점을 물어보고 다양한 서버의 플레이어들이 답변해주는 공간</p>
               </div>
             </div>
             <div className="flex items-start gap-3">

--- a/app/strategy/page.tsx
+++ b/app/strategy/page.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { BookOpen, MessageSquare, Users, Lightbulb } from "lucide-react"
+
+export default function StrategyPage() {
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* 페이지 헤더 */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <BookOpen className="h-8 w-8 text-primary" />
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">공략 공유</h1>
+            <p className="text-muted-foreground">
+              다양한 공략과 팁을 공유해주세요
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 준비중 메시지 카드 */}
+      <Card className="border-dashed border-2 border-muted-foreground/25">
+        <CardHeader className="text-center pb-4">
+          <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-muted">
+            <MessageSquare className="h-10 w-10 text-muted-foreground" />
+          </div>
+          <CardTitle className="text-2xl">오픈 준비중입니다</CardTitle>
+          <CardDescription className="text-base max-w-md mx-auto">
+            연맹원들이 서로의 공략과 전략을 공유할 수 있는 게시판을 준비하고 있습니다.
+            곧 만나볼 수 있도록 열심히 개발 중이니 조금만 기다려주세요!
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="flex flex-col items-center text-center p-4 rounded-lg bg-muted/30">
+              <Users className="h-8 w-8 text-primary mb-2" />
+              <h3 className="font-semibold mb-1">연맹원 소통</h3>
+              <p className="text-sm text-muted-foreground">
+                연맹원들과 함께 전략을 공유하고 토론할 수 있습니다
+              </p>
+            </div>
+            <div className="flex flex-col items-center text-center p-4 rounded-lg bg-muted/30">
+              <Lightbulb className="h-8 w-8 text-primary mb-2" />
+              <h3 className="font-semibold mb-1">공략 팁 모음</h3>
+              <p className="text-sm text-muted-foreground">
+                게임 내 다양한 공략과 유용한 팁들을 한곳에서 확인하세요
+              </p>
+            </div>
+            <div className="flex flex-col items-center text-center p-4 rounded-lg bg-muted/30">
+              <BookOpen className="h-8 w-8 text-primary mb-2" />
+              <h3 className="font-semibold mb-1">가이드 공유</h3>
+              <p className="text-sm text-muted-foreground">
+                초보자부터 고수까지, 모든 레벨의 가이드를 공유해보세요
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 추가 정보 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">앞으로 제공될 기능들</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3">
+              <div className="w-2 h-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+              <div>
+                <h4 className="font-medium">전략 게시판</h4>
+                <p className="text-sm text-muted-foreground">사막전, 연맹전 등 다양한 콘텐츠별 전략 공유</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="w-2 h-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+              <div>
+                <h4 className="font-medium">팁 & 노하우</h4>
+                <p className="text-sm text-muted-foreground">게임 플레이에 도움이 되는 각종 팁과 노하우</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="w-2 h-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+              <div>
+                <h4 className="font-medium">질문 & 답변</h4>
+                <p className="text-sm text-muted-foreground">궁금한 점을 물어보고 연맹원들이 답변해주는 공간</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="w-2 h-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+              <div>
+                <h4 className="font-medium">카테고리별 분류</h4>
+                <p className="text-sm text-muted-foreground">콘텐츠 유형별로 정리된 체계적인 정보 관리</p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
-import { Users, UserSquare, Menu, X, Shuffle, ChevronRight, ChevronLeft, LayoutDashboard, LogOut, User, Edit3, Loader2 } from "lucide-react"
+import { Users, UserSquare, Menu, X, Shuffle, ChevronRight, ChevronLeft, LayoutDashboard, LogOut, User, Edit3, Loader2, BookOpen } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Input } from "@/components/ui/input"
@@ -34,6 +34,11 @@ const navItems = [
     title: "사막전 관리",
     href: "/events",
     icon: UserSquare,
+  },
+  {
+    title: "공략 공유",
+    href: "/strategy",
+    icon: BookOpen,
   },
   {
     title: "연맹원 랜덤뽑기",

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 right-0 z-[100] flex max-h-screen w-full flex-col p-4 sm:top-0 sm:right-0 sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 5000
+const TOAST_REMOVE_DELAY = 2500
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- 토스트 메시지 위치를 우측하단에서 우측상단으로 변경하여 플로팅 채팅 버튼과의 겹침 해결
- 사이드바에 "공략 공유" 메뉴 추가 (사막전관리 페이지 아래 위치)
- 새로운 공략 공유 페이지 생성 (/strategy)

## 변경 사항
1. **토스트 위치 변경**: `components/ui/toast.tsx`에서 ToastViewport 위치를 top-right로 수정
2. **사이드바 메뉴 추가**: `components/sidebar.tsx`에 "공략 공유" 메뉴 항목 추가 (BookOpen 아이콘 사용)
3. **새 페이지 생성**: `app/strategy/page.tsx` - 오픈 준비중 메시지가 포함된 게시판 스타일 페이지
4. **로딩 페이지 추가**: `app/strategy/loading.tsx` - 일관된 로딩 UI 제공

## UI/UX 개선
- 플로팅 채팅 버튼과 토스트 메시지 겹침 해결
- 직관적인 사이드바 네비게이션 구조 (사막전관리 → 공략 공유 → 연맹원 랜덤뽑기)
- 사용자 친화적인 준비중 페이지 디자인 (예정 기능 안내 포함)

## Test plan
- [x] 토스트 메시지가 우측상단에 정상 표시되는지 확인
- [x] 사이드바에 "공략 공유" 메뉴가 올바른 위치에 표시되는지 확인
- [x] /strategy 경로로 접근 시 페이지가 정상 로드되는지 확인
- [x] 모바일 환경에서도 사이드바 메뉴가 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)