### PR TITLE
refactor: VIP 라벨을 SPONSOR(후원)로 변경

### DIFF
--- a/lib/user-label-utils.ts
+++ b/lib/user-label-utils.ts
@@ -3,7 +3,7 @@
  * 백엔드 ENUM 값을 한글 라벨과 스타일로 매핑
  */
 
-export type UserLabelType = 'MASTER' | 'VIP' | 'PREMIUM' | 'MODERATOR' | 'SUPPORTERS'
+export type UserLabelType = 'MASTER' | 'SPONSOR' | 'PREMIUM' | 'MODERATOR' | 'SUPPORTERS'
 
 export interface LabelStyle {
   displayName: string
@@ -22,8 +22,8 @@ const LABEL_STYLES: Record<UserLabelType, LabelStyle> = {
     textColor: 'text-red-800 dark:text-red-300',
     borderColor: 'border-red-200 dark:border-red-700'
   },
-  VIP: {
-    displayName: 'VIP',
+  SPONSOR: {
+    displayName: '후원',
     bgColor: 'bg-yellow-100 dark:bg-yellow-900/20',
     textColor: 'text-yellow-800 dark:text-yellow-300',
     borderColor: 'border-yellow-200 dark:border-yellow-700'
@@ -89,7 +89,7 @@ const LABEL_PRIORITY: Record<UserLabelType, number> = {
   MASTER: 1,
   MODERATOR: 2, 
   SUPPORTERS: 3,
-  VIP: 4,
+  SPONSOR: 4,
   PREMIUM: 5
 }
 


### PR DESCRIPTION
## Summary
사용자 라벨 VIP를 SPONSOR(후원)로 변경하여 한글화 및 의미 명확화

## Changes Made

### 🎨 UserLabel 유틸리티 업데이트
- **VIP → SPONSOR**: TypeScript 타입 및 enum 값 변경
- **표시명 변경**: "VIP" → "후원"으로 한글화
- **스타일 유지**: 기존 노란색 계열 디자인 그대로 유지
- **우선순위 유지**: 4순위 우선순위 동일하게 유지

### 📁 수정된 파일들
- `lib/user-label-utils.ts` - UserLabelType, LABEL_STYLES, LABEL_PRIORITY 업데이트

### 🎯 UI 개선 효과
- **채팅 메시지**: 사용자명 옆에 "후원" 뱃지 표시
- **의미 명확화**: VIP보다 "후원"이 더 직관적이고 친숙한 표현
- **다크모드 지원**: 기존과 동일한 완벽한 다크모드 지원
- **반응형 디자인**: 모바일에서도 적절히 표시

## Test Plan
- [x] TypeScript 타입 체크 완료
- [x] Next.js 빌드 테스트 완료 
- [x] 컴포넌트에서 SPONSOR 라벨 렌더링 확인
- [ ] 채팅 UI에서 "후원" 뱃지 표시 테스트
- [ ] 다크모드 스타일 확인

## Visual Changes
### Before
- 채팅에서 "VIP" 뱃지 표시
- 영어 표기로 직관성 부족

### After  
- 채팅에서 "후원" 뱃지 표시
- 한글 표기로 의미 명확화
- 동일한 노란색 스타일 유지

## Compatibility
- **백엔드 연동**: lastwar-api의 SPONSOR enum과 완전 호환
- **기존 데이터**: 마이그레이션 후 모든 기존 VIP 사용자가 후원자로 표시
- **타입 안전성**: TypeScript로 컴파일 타임 검증 완료

🤖 Generated with [Claude Code](https://claude.ai/code)