### PR TITLE
fix: 플로팅 채팅 버튼과 모달 겹침 문제 해결 및 UI 개선

### DIFF
--- a/components/chat/chat-modal.tsx
+++ b/components/chat/chat-modal.tsx
@@ -33,15 +33,15 @@ const ChatModal = memo(function ChatModal({ isOpen, onClose, onMessageUpdate }: 
           <div
             className={`fixed z-[10001] gpu-accelerated chat-modal transition-all duration-300 ease-out ${
               isMinimized 
-                ? 'bottom-20 right-4 translate-x-0 translate-y-0' 
-                : 'bottom-2 xs:bottom-20 xs:left-auto xs:right-4 sm:right-6 left-2 right-2 xs:left-auto xs:right-4'
+                ? 'bottom-24 right-4 translate-x-0 translate-y-0' 
+                : 'bottom-4 xs:bottom-24 xs:left-auto xs:right-4 sm:right-6 left-2 right-2 xs:left-auto xs:right-4'
             }`}
           >
             <Card 
               className={`shadow-2xl border-0 overflow-hidden ${
                 isMinimized 
                   ? "w-48 h-14 rounded-2xl" 
-                  : "w-full h-[calc(100vh-6rem)] xs:w-[380px] xs:h-[520px] sm:w-[400px] sm:h-[560px] md:w-[440px] md:h-[640px] xs:max-w-none xs:rounded-2xl rounded-t-2xl xs:rounded-b-2xl"
+                  : "w-full h-[calc(100vh-4rem)] xs:w-[380px] xs:h-[546px] sm:w-[400px] sm:h-[588px] md:w-[440px] md:h-[672px] xs:max-w-none xs:rounded-2xl rounded-t-2xl xs:rounded-b-2xl"
               }`}
             >
               {/* 채팅 내용 - 모달 오픈 상태 전달 */}

--- a/components/chat/chat-modal.tsx
+++ b/components/chat/chat-modal.tsx
@@ -29,19 +29,19 @@ const ChatModal = memo(function ChatModal({ isOpen, onClose, onMessageUpdate }: 
             onClick={onClose}
           />
 
-          {/* 채팅 모달 - 부드러운 애니메이션 */}
+          {/* 채팅 모달 - 플로팅 버튼 공간 확보 */}
           <div
             className={`fixed z-[10001] gpu-accelerated chat-modal transition-all duration-300 ease-out ${
               isMinimized 
-                ? 'bottom-4 right-4 translate-x-0 translate-y-0' 
-                : 'bottom-4 xs:bottom-4 xs:left-auto xs:right-4 sm:right-6 left-2 right-2 xs:left-auto xs:right-4'
+                ? 'bottom-20 right-4 translate-x-0 translate-y-0' 
+                : 'bottom-2 xs:bottom-20 xs:left-auto xs:right-4 sm:right-6 left-2 right-2 xs:left-auto xs:right-4'
             }`}
           >
             <Card 
               className={`shadow-2xl border-0 overflow-hidden ${
                 isMinimized 
                   ? "w-48 h-14 rounded-2xl" 
-                  : "w-full h-[80vh] h-[80dvh] xs:w-[380px] xs:h-[520px] sm:w-[400px] sm:h-[560px] md:w-[440px] md:h-[640px] xs:max-w-none xs:rounded-2xl rounded-t-2xl xs:rounded-b-2xl"
+                  : "w-full h-[calc(100vh-6rem)] xs:w-[380px] xs:h-[520px] sm:w-[400px] sm:h-[560px] md:w-[440px] md:h-[640px] xs:max-w-none xs:rounded-2xl rounded-t-2xl xs:rounded-b-2xl"
               }`}
             >
               {/* 채팅 내용 - 모달 오픈 상태 전달 */}


### PR DESCRIPTION
## Summary
플로팅 액션 버튼이 채팅 모달에 가려지는 문제를 해결하고, 모달 크기를 확대하여 사용성을 개선했습니다.

## 🐛 Problem
- **플로팅 버튼 가려짐**: 채팅 모달이 열릴 때 우측 하단의 플로팅 액션 버튼이 완전히 가려져서 모달을 닫을 수 없는 문제
- **겹치는 위치**: 플로팅 버튼(`bottom-4 right-4`)과 모달(`bottom-4 right-4`)이 정확히 같은 위치에 배치
- **사용성 저하**: 모달을 연 후 닫기 위해 헤더의 X 버튼만 사용 가능

## 🔧 Solution

### **1단계: 플로팅 버튼 겹침 해결**
```css
/* Before */
플로팅 버튼: bottom-4 right-4
채팅 모달: bottom-4 right-4  ← 겹침!

/* After */  
플로팅 버튼: bottom-4 right-4 (유지)
채팅 모달: bottom-20/bottom-24 (분리)
```

### **2단계: 모달 크기 5% 확대**
- **xs**: `520px` → `546px` (+26px, +5%)
- **sm**: `560px` → `588px` (+28px, +5%)  
- **md**: `640px` → `672px` (+32px, +5%)
- **모바일**: `calc(100vh-6rem)` → `calc(100vh-4rem)`

## 📱 Device-Specific Changes

### **모바일 (< 475px)**
- **위치**: `bottom-2` → `bottom-4`
- **높이**: `calc(100vh-6rem)` → `calc(100vh-4rem)` 
- **효과**: 플로팅 버튼 공간 확보하면서 더 큰 채팅 영역

### **데스크톱 (≥ 475px)**
- **위치**: `bottom-4` → `bottom-24`
- **크기**: 각 브레이크포인트에서 5% 증가
- **효과**: 플로팅 버튼과 완전 분리로 겹침 없음

### **최소화 상태**
- **위치**: `bottom-4` → `bottom-24`
- **효과**: 최소화된 모달도 플로팅 버튼과 분리

## 🎯 Benefits

### **UX 개선**
- ✅ 플로팅 버튼 항상 접근 가능
- ✅ 모달 열기/닫기 자유롭게 사용 가능
- ✅ 직관적인 인터페이스 동작

### **사용성 향상**
- ✅ 5% 확대된 채팅 공간으로 더 편리한 채팅
- ✅ 모든 화면 크기에서 최적화된 배치
- ✅ 일관된 여백과 안정적인 위치

### **반응형 최적화**
- ✅ 모바일과 데스크톱 각각 최적 위치
- ✅ 다양한 화면 크기 지원
- ✅ 플로팅 버튼 가시성 보장

## 🧪 Testing
- [x] 모바일에서 플로팅 버튼 접근성 테스트
- [x] 데스크톱에서 모달-버튼 간격 확인
- [x] 최소화 상태에서 버튼 가시성 검증
- [x] 다양한 화면 크기에서 반응형 테스트
- [x] 빌드 테스트 통과

## 📷 Visual Changes

### Before
- 플로팅 버튼이 모달에 완전히 가려짐
- 모달 닫기가 어려움
- 작은 채팅 공간

### After
- 플로팅 버튼 항상 보임
- 모달 열기/닫기 자유롭게 가능
- 5% 확대된 채팅 공간

## 🔍 Technical Details

### Files Changed
- `components/chat/chat-modal.tsx`: 위치 및 크기 조정

### CSS Classes Updated
- 위치: `bottom-4` → `bottom-2/bottom-24`
- 크기: 각 브레이크포인트별 5% 증가
- 모바일 높이: `calc(100vh-4rem)` 적용

### Z-index Hierarchy
```
플로팅 버튼: z-[9999]
채팅 모달: z-[10001]
```
기존 z-index 계층 구조 유지하며 위치만 조정

🤖 Generated with [Claude Code](https://claude.ai/code)