### PR TITLE
feat: 사이드바 후원하기 버튼을 'Buy me a coffee' 디자인으로 변경

### DIFF
--- a/components/ui/sponsor-button.tsx
+++ b/components/ui/sponsor-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import Image from "next/image"
-import { Heart, QrCode, Copy, Check, ExternalLink, Smartphone, Monitor } from "lucide-react"
+import { Coffee, QrCode, Copy, Check, ExternalLink, Smartphone, Monitor } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { toast } from "@/hooks/use-toast"
@@ -83,31 +83,31 @@ export default function SponsorButton({ collapsed = false }: SponsorButtonProps)
         <Button
           variant="outline"
           size={collapsed ? "icon" : "sm"}
-          className={`${collapsed ? "w-full" : "w-full justify-start gap-2"} bg-gradient-to-r from-pink-50 to-red-50 border-pink-200 hover:from-pink-100 hover:to-red-100 text-pink-700 hover:text-pink-800 transition-all duration-200`}
-          title={collapsed ? "후원하기" : undefined}
+          className={`${collapsed ? "w-full" : "w-full justify-start gap-2"} bg-gradient-to-r from-amber-50 to-orange-50 border-amber-200 hover:from-amber-100 hover:to-orange-100 text-amber-700 hover:text-amber-800 transition-all duration-200 shadow-sm hover:shadow-md`}
+          title={collapsed ? "Buy me a coffee" : undefined}
         >
-          <Heart className="h-4 w-4 text-pink-500" />
-          {!collapsed && <span className="font-medium">후원하기</span>}
+          <Coffee className="h-4 w-4 text-amber-600" />
+          {!collapsed && <span className="font-medium">Buy me a coffee ☕</span>}
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Heart className="h-5 w-5 text-pink-500" />
-            후원하기
+            <Coffee className="h-5 w-5 text-amber-600" />
+            Buy me a coffee ☕
           </DialogTitle>
           <DialogDescription>
-            더 나은 콘텐츠 제작에 보탬이 되어주시는 여러분의 따뜻한 마음에 감사드립니다. 💙
+            커피 한 잔의 후원으로 더 나은 콘텐츠 제작에 힘을 보태주세요! 여러분의 따뜻한 마음에 감사드립니다. ☕💝
           </DialogDescription>
         </DialogHeader>
         
         <div className="space-y-4 py-4">
           {/* 카카오페이 후원 */}
-          <div className="p-4 border rounded-lg bg-yellow-50 border-yellow-200">
+          <div className="p-4 border rounded-lg bg-amber-50 border-amber-200">
             <div className="flex items-center justify-between mb-3">
               <h3 className="font-semibold text-gray-900 flex items-center gap-2">
-                <QrCode className="h-4 w-4 text-yellow-600" />
-                카카오페이로 후원하기
+                <Coffee className="h-4 w-4 text-amber-600" />
+                카카오페이로 커피 사주기 ☕
               </h3>
             </div>
             
@@ -155,11 +155,11 @@ export default function SponsorButton({ collapsed = false }: SponsorButtonProps)
               onClick={handleKakaoPayClick}
               className={`w-full font-semibold flex items-center justify-center gap-2 ${
                 isMobileDevice 
-                  ? "bg-yellow-400 hover:bg-yellow-500 text-gray-900" 
+                  ? "bg-amber-400 hover:bg-amber-500 text-amber-900" 
                   : "bg-gray-200 hover:bg-gray-300 text-gray-700 cursor-help"
               }`}
             >
-              💛 {isMobileDevice ? "카카오페이로 후원하기" : "QR 코드를 스캔해주세요"}
+              ☕ {isMobileDevice ? "커피 한 잔 사주기" : "QR 코드를 스캔해주세요"}
               {isMobileDevice ? (
                 <ExternalLink className="h-4 w-4" />
               ) : (
@@ -170,7 +170,10 @@ export default function SponsorButton({ collapsed = false }: SponsorButtonProps)
 
           {/* 계좌 후원 */}
           <div className="p-4 border rounded-lg bg-blue-50 border-blue-200">
-            <h3 className="font-semibold text-gray-900 mb-3">계좌로 후원하기</h3>
+            <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
+              <Coffee className="h-4 w-4 text-blue-600" />
+              계좌로 커피 사주기
+            </h3>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span className="text-gray-600">은행명:</span>
@@ -206,9 +209,15 @@ export default function SponsorButton({ collapsed = false }: SponsorButtonProps)
           </div>
 
           {/* 감사 메시지 */}
-          <div className="text-center p-3 bg-gray-50 rounded-lg">
-            <p className="text-sm text-gray-600">
-              여러분의 후원으로 더 나은 콘텐츠 제작에 힘쓰겠습니다. 🙏
+          <div className="text-center p-4 bg-gradient-to-r from-amber-50 to-orange-50 rounded-lg border border-amber-200">
+            <div className="flex justify-center mb-2">
+              <Coffee className="h-6 w-6 text-amber-600" />
+            </div>
+            <p className="text-sm text-gray-700 font-medium">
+              커피 한 잔의 따뜻함으로 더 나은 콘텐츠를 만들어가겠습니다 ☕
+            </p>
+            <p className="text-xs text-gray-500 mt-1">
+              Thank you for your support! 🙏
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

사이드바의 후원하기 버튼을 친숙하고 국제적으로 인지도가 높은 'Buy me a coffee' 스타일로 디자인을 완전히 변경했습니다.

## 🔄 Design Transformation

### **Before → After**
- **아이콘**: ❤️ Heart → ☕ Coffee
- **색상**: 핑크/레드 계열 → 앰버/오렌지 커피 톤
- **텍스트**: "후원하기" → "Buy me a coffee ☕"
- **분위기**: 일반적인 후원 → 친근한 커피샵 컨셉

## ☕ Key Features

### **1. Coffee-themed Visual Identity**
```css
/* 새로운 커피 컬러 팔레트 */
bg-gradient-to-r from-amber-50 to-orange-50
border-amber-200
text-amber-700
Coffee icon with amber-600 color
```

### **2. Enhanced Button Design**
- **그라데이션**: 앰버-오렌지 따뜻한 커피 톤
- **그림자**: `shadow-sm hover:shadow-md` 입체감 강화
- **아이콘**: 커피 컵 아이콘으로 즉시 인식 가능
- **텍스트**: 이모지 포함으로 친근함 증대

### **3. Modal Content Updates**
- **제목**: "Buy me a coffee ☕"
- **설명**: 커피 테마 메시징
- **카카오페이**: "커피 한 잔 사주기"
- **계좌이체**: "계좌로 커피 사주기"

### **4. Improved Thank You Section**
```jsx
<div className="bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-200">
  <Coffee className="h-6 w-6 text-amber-600" />
  <p>커피 한 잔의 따뜻함으로 더 나은 콘텐츠를 만들어가겠습니다 ☕</p>
  <p>Thank you for your support! 🙏</p>
</div>
```

## 🎯 Benefits

### **사용자 경험 개선**
- ✅ **친숙한 컨셉**: 'Buy me a coffee'는 전 세계적으로 인지도 높은 후원 방식
- ✅ **부담감 완화**: "후원"보다 "커피 한 잔"이 더 가벼운 느낌
- ✅ **국제화**: 영어 텍스트로 해외 사용자도 이해하기 쉬움

### **시각적 개선**
- ✅ **일관된 테마**: 커피 아이콘과 앰버 컬러로 통일성 확보
- ✅ **향상된 디자인**: 그림자와 그라데이션으로 현대적 느낌
- ✅ **직관적 인식**: 커피 아이콘으로 용도 명확화

### **브랜딩 효과**
- ✅ **차별화**: 일반적인 하트 아이콘에서 고유한 커피 테마로
- ✅ **기억하기 쉬움**: 'Buy me a coffee' 브랜딩 효과
- ✅ **친근한 이미지**: 커뮤니티 지향적 플랫폼에 적합

## 🖼️ Visual Changes

### **Button (Collapsed/Expanded)**
| State | Before | After |
|-------|--------|-------|
| Icon | ❤️ Heart (pink) | ☕ Coffee (amber) |
| Color | Pink/Red gradient | Amber/Orange gradient |
| Text | "후원하기" | "Buy me a coffee ☕" |
| Shadow | Basic | Enhanced (hover effect) |

### **Modal Design**
| Section | Update |
|---------|--------|
| Header | Coffee icon + "Buy me a coffee ☕" |
| KakaoPay | Amber background + "커피 한 잔 사주기" |
| Bank Transfer | Coffee icon + "계좌로 커피 사주기" |
| Thanks | Gradient background + bilingual message |

## 🧪 Technical Details

### **Files Modified**
- `components/ui/sponsor-button.tsx`: Complete design transformation

### **Dependencies**
- **Added**: `Coffee` icon from lucide-react
- **Removed**: `Heart` icon references
- **Updated**: Color classes throughout component

### **Backward Compatibility**
- ✅ All existing functionality preserved
- ✅ KakaoPay integration unchanged
- ✅ Bank transfer feature maintained
- ✅ Mobile/desktop responsive behavior
- ✅ Environment variable usage intact

## 🔍 Testing

- [x] 사이드바 접힘/펼침 상태에서 버튼 표시 확인
- [x] 모달 열기/닫기 정상 동작
- [x] 카카오페이 기능 유지
- [x] 계좌정보 복사 기능 동작
- [x] 모바일/데스크톱 반응형 확인
- [x] 개발 환경 빌드 테스트 통과

## 🎨 Design Philosophy

**"Buy me a coffee"**는 단순한 디자인 변경을 넘어 사용자와 크리에이터 간의 관계를 더욱 친근하고 접근하기 쉽게 만드는 변화입니다. 커피 한 잔의 가격으로 콘텐츠를 응원한다는 개념은 전 세계적으로 사랑받는 후원 문화로, 부담스럽지 않으면서도 의미 있는 지원 방법입니다.

🤖 Generated with [Claude Code](https://claude.ai/code)