### PR TITLE
실시간 채팅 모달에서 자신의 메시지에도 프로필 정보 표시

### DIFF
--- a/components/chat/message-bubble.tsx
+++ b/components/chat/message-bubble.tsx
@@ -363,32 +363,84 @@ const MessageBubble = memo(function MessageBubble({
   if (message.isMyMessage) {
     return (
       <div className="flex justify-end gpu-accelerated message-bubble animate-in slide-in-from-right-2 duration-200">
-        <div className="flex items-end gap-1.5 xs:gap-2 max-w-[85%] xs:max-w-[90%] sm:max-w-[85%] md:max-w-[80%]">
-          {/* 시간 및 액션 - 선택 모드일 때는 항상 표시, 일반 모드일 때는 마지막에만 표시 */}
-          {(isSelectable || isLastInGroup) && (
-            <div className="flex items-center gap-1 mb-1">
-              {/* 시간은 마지막 그룹에만 표시 */}
-              {isLastInGroup && (
-                <span className="text-xs text-gray-500 whitespace-nowrap">
-                  {formatChatTime(message.createdAt)}
+        <div className="flex items-start gap-1.5 xs:gap-2 max-w-[85%] xs:max-w-[90%] sm:max-w-[85%] md:max-w-[80%]">
+          {/* 메시지 컨테이너 */}
+          <div className="flex-1 min-w-0">
+            {/* 사용자 정보 (연속 메시지의 첫번째에만 표시) */}
+            {isFirstInGroup && (
+              <div className="flex items-center justify-end gap-1 xs:gap-2 mb-1 overflow-hidden">
+                {message.userLabel && (() => {
+                  const labelDisplayName = getLabelDisplayName(message.userLabel)
+                  const labelStyle = getLabelStyle(message.userLabel)
+                  
+                  if (!labelDisplayName || !labelStyle) return null
+                  
+                  return (
+                    <Badge 
+                      variant="outline" 
+                      className={`text-xs h-3 xs:h-4 px-1 hidden xs:inline-flex ${labelStyle.bgColor} ${labelStyle.textColor} ${labelStyle.borderColor}`}
+                    >
+                      {labelDisplayName}
+                    </Badge>
+                  )
+                })()}
+                {message.userTag && (
+                  <Badge variant="outline" className="text-xs h-3 xs:h-4 px-1 hidden xs:inline-flex">
+                    {message.userTag}
+                  </Badge>
+                )}
+                <span className="text-xs xs:text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
+                  {message.roomType === "GLOBAL" && message.serverTag && message.allianceName ? (
+                    <>
+                      <span className="text-xs text-gray-500 hidden xs:inline">#{message.serverTag}</span>
+                      <span className="text-xs text-blue-600 dark:text-blue-400 mx-1 hidden xs:inline">[{message.allianceName}]</span>
+                      <span>{message.userName}</span>
+                    </>
+                  ) : (
+                    message.userName
+                  )}
                 </span>
-              )}
-              {renderAdminControls()}
-            </div>
-          )}
-
-          {/* 메시지 버블 */}
-          <div className="bg-blue-500 text-white px-2.5 xs:px-3 py-1.5 xs:py-2 rounded-2xl rounded-br-md shadow-sm will-change-transform max-w-[200px] xs:max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden">
-            {message.hiddenByAdmin ? (
-              <p className="text-xs xs:text-sm italic text-blue-100">
-                <span className="hidden xs:inline">관리자가 해당 메시지를 가렸습니다.</span>
-                <span className="xs:hidden">메시지가 가려짐</span>
-              </p>
-            ) : (
-              <p className="text-xs xs:text-sm whitespace-pre-wrap force-break-word max-w-full min-w-0 break-all">
-                {message.content}
-              </p>
+              </div>
             )}
+
+            {/* 메시지 버블과 시간 */}
+            <div className="flex items-end gap-1.5 xs:gap-2 justify-end">
+              {/* 시간 및 액션 - 선택 모드일 때는 항상 표시, 일반 모드일 때는 마지막에만 표시 */}
+              {(isSelectable || isLastInGroup) && (
+                <div className="flex items-center gap-1 mb-1">
+                  {/* 시간은 마지막 그룹에만 표시 */}
+                  {isLastInGroup && (
+                    <span className="text-xs text-gray-500 whitespace-nowrap">
+                      {formatChatTime(message.createdAt)}
+                    </span>
+                  )}
+                  {renderAdminControls()}
+                </div>
+              )}
+
+              {/* 메시지 버블 */}
+              <div className="bg-blue-500 text-white px-2.5 xs:px-3 py-1.5 xs:py-2 rounded-2xl rounded-br-md shadow-sm will-change-transform max-w-[200px] xs:max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden">
+                {message.hiddenByAdmin ? (
+                  <p className="text-xs xs:text-sm italic text-blue-100">
+                    <span className="hidden xs:inline">관리자가 해당 메시지를 가렸습니다.</span>
+                    <span className="xs:hidden">메시지가 가려짐</span>
+                  </p>
+                ) : (
+                  <p className="text-xs xs:text-sm whitespace-pre-wrap force-break-word max-w-full min-w-0 break-all">
+                    {message.content}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 사용자 아바타 (연속 메시지의 첫번째에만 표시) */}
+          <div className={`w-7 h-7 xs:w-8 xs:h-8 rounded-full flex items-center justify-center text-white text-xs font-bold mt-1 flex-shrink-0 ${
+            isFirstInGroup 
+              ? 'bg-gradient-to-br from-green-400 to-blue-500' 
+              : 'bg-transparent' // 연속 메시지에서는 투명하게
+          }`}>
+            {isFirstInGroup && message.userName.charAt(0)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 실시간 채팅 모달에서 자신의 메시지에도 프로필 정보 표시 기능 구현
- 기존에는 상대방 메시지만 프로필 정보를 보여줬지만, 이제 자신의 메시지도 동일하게 표시
- UI 일관성 확보 및 사용자 경험 개선

## 주요 변경사항
- **MessageBubble 컴포넌트 수정**: 내 메시지(isMyMessage)에도 프로필 정보 표시 로직 추가
- **프로필 정보 포함**: 사용자 아바타, 이름, 서버 태그, 얼라이언스명, 사용자 태그, 라벨
- **레이아웃 개선**: 오른쪽 정렬은 유지하되 프로필 정보 구성은 상대방과 동일
- **시각적 구분**: 내 메시지 아바타는 green-blue 그라디언트로 구분

## 기술적 세부사항
- 기존 상대방 메시지의 프로필 정보 렌더링 로직을 자신의 메시지에도 적용
- `isFirstInGroup` 조건에 따라 연속 메시지의 첫 번째에만 프로필 정보 표시
- 반응형 디자인 유지 (모바일/태블릿/데스크톱)
- 성능 최적화된 렌더링 로직 유지

## Test plan
- [ ] 실시간 채팅에서 자신의 메시지에 프로필 정보 표시 확인
- [ ] 연속 메시지에서 첫 번째에만 프로필 정보 표시되는지 확인  
- [ ] 모바일/태블릿/데스크톱에서 반응형 동작 확인
- [ ] 다양한 사용자 라벨/태그 조합에서 정상 표시 확인
- [ ] 성능 및 애니메이션 부드러움 확인

🤖 Generated with [Claude Code](https://claude.ai/code)