### PR TITLE
feat: 게시글 수정 시 기존 이미지 정보 보존 기능 추가

### DIFF
--- a/app/board/posts/[postId]/edit/page.tsx
+++ b/app/board/posts/[postId]/edit/page.tsx
@@ -48,7 +48,8 @@ export default function EditPostPage() {
       title: post.title,
       content: post.content || '',
       categoryId: post.categoryId,
-      thumbnailUrl: post.thumbnailUrl
+      thumbnailUrl: post.thumbnailUrl,
+      contentImages: post.contentImages || []  // 기존 이미지 정보 포함
     };
   };
 

--- a/components/board/board-post-form.tsx
+++ b/components/board/board-post-form.tsx
@@ -45,6 +45,7 @@ interface BoardPostFormProps {
     content: string;
     categoryId: number;
     thumbnailUrl?: string;
+    contentImages?: ContentImageRequest[];  // 기존 이미지 정보
   };
 }
 
@@ -61,7 +62,7 @@ export function BoardPostForm({ postId, initialData }: BoardPostFormProps) {
     categoryId: initialData?.categoryId || 0
   });
 
-  const [contentImages, setContentImages] = useState<ContentImageRequest[]>([]);
+  const [contentImages, setContentImages] = useState<ContentImageRequest[]>(initialData?.contentImages || []);
   
   // 임시 이미지 파일 저장 (blob URL과 실제 File 객체 매핑)
   const [tempImageFiles, setTempImageFiles] = useState<Map<string, File>>(new Map());

--- a/types/board.ts
+++ b/types/board.ts
@@ -62,6 +62,7 @@ export interface BoardPost {
   postStatus: string;
   createdAt: string;
   updatedAt: string;
+  contentImages?: ContentImageRequest[];  // 게시글 이미지 목록 (수정 시 사용)
 }
 
 export interface BoardPostResponse extends BoardPost {}


### PR DESCRIPTION
## Summary
- 게시글 수정 시 기존 이미지 정보가 손실되는 문제 해결
- 글자만 수정할 때도 기존 이미지가 유지되도록 개선

## Changes
- `BoardPost` 타입에 `contentImages` 필드 추가
- `BoardPostForm`에서 초기 데이터로 `contentImages` 활용
- 게시글 수정 페이지에서 기존 이미지 정보를 폼에 전달

## Backend Changes Required
- 백엔드 API에서 게시글 상세 조회 시 `contentImages` 필드 포함 필요
- 관련 백엔드 PR: https://github.com/ljy9303/lastwar-api/pull/43

## Test Plan
- [x] 프론트엔드 빌드 테스트 통과
- [ ] 게시글 수정 시 기존 이미지 보존 확인
- [ ] 새 이미지 추가/삭제 시 정상 동작 확인
- [ ] 백엔드 연동 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)