### PR TITLE
🐛 스쿼드 팀 구성 확정 시 포지션 정보 저장 오류 수정

### DIFF
--- a/app/squads/page.tsx
+++ b/app/squads/page.tsx
@@ -635,7 +635,7 @@ export default function SquadsPage() {
           members.forEach((user) => {
             allChanges[user.userSeq] = {
               desertType: team, // 현재 속해 있는 팀으로 desert_type 설정
-              position: user.position || -1,
+              position: pendingChanges[user.userSeq]?.position ?? user.position ?? -1, // pendingChanges에서 우선 가져오기
             }
           })
         }


### PR DESCRIPTION
$(cat <<'EOF'
## 🐛 문제점

스쿼드 관리 페이지에서 **팀 구성 확정** 버튼 클릭 시 사용자가 설정한 포지션 정보가 저장되지 않고 `-1` (기본값)로 저장되는 문제가 발생했습니다.

### 원인 분석
- `confirmSquads` 함수에서 포지션 정보를 가져올 때 `user.position` (기존 DB 데이터)만 사용
- `pendingChanges`에 저장된 사용자가 변경한 포지션 정보를 무시하는 로직 오류

## 🔧 해결방법

```typescript
// 수정 전
position: user.position || -1,

// 수정 후
position: pendingChanges[user.userSeq]?.position ?? user.position ?? -1,
```

### 우선순위 로직
1. `pendingChanges`에서 사용자가 변경한 포지션 정보 우선 적용
2. 변경사항이 없으면 기존 `user.position` 사용
3. 모두 없으면 기본값 `-1` 적용

## 🧪 테스트 시나리오

1. ✅ A조/B조에서 포지션 설정 (1시, 2시, 공격/지원 등)
2. ✅ 팀 구성 확정 버튼 클릭
3. ✅ 데이터베이스에 설정한 포지션 값이 정상 저장됨

## 📁 변경된 파일

- `app/squads/page.tsx`: 포지션 정보 수집 로직 수정 (1줄)

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)