### PR TITLE
fix: 로그인/회원가입 페이지에서 채팅 API 호출 오류 수정

### DIFF
--- a/lib/api-service.ts
+++ b/lib/api-service.ts
@@ -14,7 +14,7 @@ export async function fetchFromAPI<T = any>(endpoint: string, options: RequestIn
     console.log(`[FRONTEND] API 요청 시작 - ${method} ${endpoint}`, options.body ? { body: options.body } : '')
   }
 
-  // 로그인/회원가입 페이지에서 채팅 API 호출 차단
+  // 로그인/회원가입 페이지에서 채팅 API 호출 차단 (조용히 처리)
   if (typeof window !== 'undefined' && endpoint.includes('/chat/')) {
     const currentPath = window.location.pathname
     const authPages = ['/login', '/signup', '/test-login', '/auth/kakao/callback']
@@ -22,9 +22,12 @@ export async function fetchFromAPI<T = any>(endpoint: string, options: RequestIn
     
     if (isAuthPage) {
       console.warn(`[FRONTEND] 로그인/회원가입 페이지에서 채팅 API 호출 차단 - ${currentPath}`)
-      const error = new Error('로그인/회원가입 페이지에서는 채팅 기능을 사용할 수 없습니다.') as Error & { status?: number; data?: any }
-      error.status = 403
-      throw error
+      // 에러를 던지는 대신 빈 응답 반환
+      return Promise.resolve({
+        success: false,
+        message: '로그인/회원가입 페이지에서는 채팅 기능을 사용할 수 없습니다.',
+        data: null
+      } as T)
     }
   }
 


### PR DESCRIPTION
## 문제점
로그인/회원가입 페이지에서 채팅 API 호출 시 Error 객체를 던져서 애플리케이션이 중단되는 문제 발생

```
Error: 로그인/회원가입 페이지에서는 채팅 기능을 사용할 수 없습니다.
lib/api-service.ts (25:21) @ fetchFromAPI
```

## 해결 방법
- Error 객체를 던지는 대신 성공적인 응답으로 조용히 처리
- 애플리케이션 중단 없이 채팅 기능을 차단
- 콘솔 경고 메시지는 유지하여 디버깅 지원

## 변경사항
### Before
```typescript
const error = new Error('로그인/회원가입 페이지에서는 채팅 기능을 사용할 수 없습니다.')
error.status = 403
throw error
```

### After
```typescript
return Promise.resolve({
  success: false,
  message: '로그인/회원가입 페이지에서는 채팅 기능을 사용할 수 없습니다.',
  data: null
} as T)
```

## 테스트 계획
- [ ] 로그인 페이지에서 채팅 기능 호출 시 오류 없이 차단되는지 확인
- [ ] 회원가입 페이지에서 채팅 기능 호출 시 오류 없이 차단되는지 확인
- [ ] 정상 페이지에서 채팅 기능이 올바르게 작동하는지 확인
- [ ] 콘솔 경고 메시지가 정상적으로 출력되는지 확인

## 영향 범위
- `lib/api-service.ts` 파일만 수정
- 기존 채팅 기능에는 영향 없음
- 로그인/회원가입 페이지의 안정성 향상

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>