### PR TITLE
fix: DialogDescription HTML hydration 오류 수정

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -433,10 +433,11 @@ export default function Sidebar() {
           <DialogHeader>
             <DialogTitle>닉네임 수정</DialogTitle>
             <DialogDescription className="space-y-2">
-              <div>새로운 닉네임을 입력해주세요. 2~20자 사이의 영문자, 숫자, 한글만 사용할 수 있습니다.</div>
-              <div className="text-amber-600 font-medium">
+              새로운 닉네임을 입력해주세요. 2~20자 사이의 영문자, 숫자, 한글만 사용할 수 있습니다.
+              <br />
+              <span className="text-amber-600 font-medium">
                 ⚠️ 닉네임 변경이 완료되면 자동으로 로그아웃되며, 다시 로그인해야 합니다.
-              </div>
+              </span>
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">


### PR DESCRIPTION
## 문제점
사이드바 닉네임 수정 버튼 클릭 시 HTML hydration 오류가 발생했습니다.

```
In HTML, <div> cannot be a descendant of <p>.
This will cause a hydration error.
```

## 원인
`DialogDescription` 컴포넌트가 내부적으로 `<p>` 태그로 렌더링되는데, 그 안에 `<div>` 요소들을 넣어서 잘못된 HTML 구조가 되었습니다.

### Before (문제가 있던 구조)
```tsx
<DialogDescription className="space-y-2">
  <div>새로운 닉네임을 입력해주세요...</div>
  <div className="text-amber-600 font-medium">
    ⚠️ 닉네임 변경이 완료되면...
  </div>
</DialogDescription>
```

### After (수정된 구조)  
```tsx
<DialogDescription className="space-y-2">
  새로운 닉네임을 입력해주세요. 2~20자 사이의 영문자, 숫자, 한글만 사용할 수 있습니다.
  <br />
  <span className="text-amber-600 font-medium">
    ⚠️ 닉네임 변경이 완료되면 자동으로 로그아웃되며, 다시 로그인해야 합니다.
  </span>
</DialogDescription>
```

## 해결 방법
- `<div>` 요소들을 제거하고 텍스트와 `<span>`, `<br>` 요소로 변경
- HTML 구조가 올바르게 되면서 hydration 오류 해결
- 시각적 스타일과 기능은 그대로 유지

## 테스트 확인사항
- [ ] 사이드바 닉네임 수정 버튼 클릭 시 hydration 오류 없음
- [ ] 모달 텍스트 표시가 정상적으로 렌더링됨
- [ ] 경고 메시지 스타일링 정상 작동
- [ ] 닉네임 수정 기능 정상 작동

## 영향 범위
- `components/sidebar.tsx` 파일의 닉네임 수정 모달만 수정
- 기존 기능과 스타일에는 영향 없음
- HTML 표준 준수로 브라우저 호환성 개선

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>